### PR TITLE
Fix stylistic issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="chrome=1">
         <title>
-            Wordpress-Gear
+            WordPress-Gear
         </title>
         <link rel="stylesheet" href="stylesheets/styles.css">
         <link rel="stylesheet" href="stylesheets/pygment_trac.css">
@@ -21,7 +21,7 @@
     </head>
     <body>
         <header>
-            <h1>Wordpress-Gear</h1>
+            <h1>WordPress-Gear</h1>
             <p>
                 Swag for WP developers
             </p>
@@ -37,7 +37,7 @@
                     Welcome
                 </h2>
                 <p>
-                    Wordpress-Gear is a compendium of useful <samp><i>developer</i></samp> tools for working with WordPress.
+                    WordPress-Gear is a compendium of useful <samp><i>developer</i></samp> tools for working with WordPress.
                 </p>
                 <ul>
                     <li>Base Tools
@@ -51,10 +51,10 @@
                     How
                 </h3>
                 <p>
-                    Wordpress-Gear is meant to be community driven, please feel free to jump in and add/remove any useful information via github.
+                    WordPress-Gear is meant to be community driven, please feel free to jump in and add/remove any useful information via GitHub.
                 </p>
                 <p>
-                    To submit pull requests <a href="https://github.com/wycks/WordPress-Gear">fork</a> this project on github then clone it locally, or edit it right in GitHub.
+                    To submit pull requests <a href="https://github.com/wycks/WordPress-Gear">fork</a> this project on GitHub then clone it locally, or edit it right in GitHub.
                 </p>
 <pre>
 <code>$ git clone git://github.com/your_username/your_fork.git
@@ -83,7 +83,7 @@ $ git push
                 </h2>
                 <dl>
                     <dd>
-                        <div class="grey-line"><div class="file">J</div>Wordpress</div>
+                        <div class="grey-line"><div class="file">J</div>WordPress</div>
                     </dd>
                     <dd>
                         <h5>
@@ -102,13 +102,13 @@ $ git push
                         </h5>
                         <ul>
                             <li>
-                                <a href="http://core.svn.wordpress.org/">SVN</a> Subversion
+                                <a href="http://core.svn.wordpress.org/">SVN</a> (Subversion)
                             </li>
                             <li>
-                                <a href="https://github.com/WordPress/WordPress">GitHub</a> Git
+                                <a href="https://github.com/WordPress/WordPress">GitHub</a> (Git)
                             </li>
                             <li>
-                                <a href="https://bitbucket.org/Rarst/wordpress/overview">BitBucket</a> Mercurial
+                                <a href="https://bitbucket.org/Rarst/wordpress/overview">BitBucket</a> (Mercurial)
                             </li>
                         </ul>
                     </dd>
@@ -121,14 +121,14 @@ $ git push
                     </dd>
                     <dd>
                         <h5>
-                            Core Testing and profiling via PhpUnit + official theme sample data
+                            Core Testing and profiling via PHPUnit + official theme sample data
                         </h5>
                         <ul>
                             <li>
                                 <a href="http://unit-tests.svn.wordpress.org/trunk/">Trac SVN</a>
                             </li>
                             <li>
-                                <a href="https://github.com/kurtpayne/wordpress-unit-tests">Github mirror</a>
+                                <a href="https://github.com/kurtpayne/wordpress-unit-tests">GitHub mirror</a>
                             </li>
                             <li>
                                 <a href="https://wpcom-themes.svn.automattic.com/demo/theme-unit-test-data.xml">Theme XML sample data</a>
@@ -145,7 +145,7 @@ $ git push
                     <dd>
                         <ul>
                             <li>
-                                <a href="https://github.com/wp-cli/wp-cli">WP-CLI</a> The command-line tool for managing WordPress.
+                                <a href="https://github.com/wp-cli/wp-cli">WP-CLI</a> - The command-line tool for managing WordPress.
                             </li>
                         </ul>
                         <ul>
@@ -155,19 +155,19 @@ $ git push
                                 </h5>
                             </li>
                             <li>
-                                <a href="https://github.com/markjaquith/WP-Stack">WP Stack</a> Capistrano deploy
+                                <a href="https://github.com/markjaquith/WP-Stack">WP Stack</a> - Capistrano deploy
                             </li>
                             <li>
-                                <a href="https://github.com/welaika/wordmove">Wordmove</a> Rails gem
+                                <a href="https://github.com/welaika/wordmove">Wordmove</a> - Rails gem
                             </li>
                             <li>
-                                <a href="https://github.com/welaika/wordmove">Wp Project Tools</a> Fabric/Python CLI and automation
+                                <a href="https://github.com/welaika/wordmove">Wp Project Tools</a> - Fabric/Python CLI and automation
                             </li>
                             <li>
-                                <a href="https://github.com/wycks/WordPhing">WordPhing</a> Phing/Php build script
+                                <a href="https://github.com/wycks/WordPhing">WordPhing</a> - Phing/Php build script
                             </li>
                             <li>
-                                <a href="https://github.com/romainberger/yeoman-wordpress">Yeoman-WordPress</a> Node, NPM and Ruby
+                                <a href="https://github.com/romainberger/yeoman-wordpress">Yeoman-WordPress</a> - Node, NPM and Ruby
                             </li>
                         </ul>
                         <ul>
@@ -177,10 +177,10 @@ $ git push
                                 </h5>
                             </li>
                             <li>
-                                <a href="https://github.com/welaika/wordless">Wordless</a> Haml, Compass and Coffeescript (Ruby)
+                                <a href="https://github.com/welaika/wordless">Wordless</a> - Haml, Compass and Coffeescript (Ruby)
                             </li>
                             <li>
-                                <a href="https://github.com/thethemefoundry/forge">Forge</a> Sass, LESS, and CoffeeScript (Ruby)
+                                <a href="https://github.com/thethemefoundry/forge">Forge</a> - Sass, LESS, and CoffeeScript (Ruby)
                             </li>
                         </ul>
                     </dd>
@@ -221,13 +221,13 @@ $ git push
                     <dd>
                         <ul>
                             <li>
-                                <a href="https://github.com/scribu/wp-phptidy">WP-PhpTidy</a> Format PHP code so that it conforms to the WordPress Coding Standards
+                                <a href="https://github.com/scribu/wp-phptidy">WP-PhpTidy</a> - Format PHP code so that it conforms to the WordPress Coding Standards
                             </li>
                             <li>
-                                <a href="https://github.com/perusio/wordpress-nginx">Nginx</a> Configuration for running WordPress
+                                <a href="https://github.com/perusio/wordpress-nginx">Nginx</a> - Configuration for running WordPress
                             </li>
                             <li>
-                                <a href="https://github.com/markjaquith/WordPress-Skeleton">WordPress-Skeleton</a> Basic layout of a WordPress Git repository
+                                <a href="https://github.com/markjaquith/WordPress-Skeleton">WordPress-Skeleton</a> - Basic layout of a WordPress Git repository
                             </li>
                         </ul>
                     </dd>
@@ -250,22 +250,22 @@ $ git push
                         </h5>
                         <ul>
                             <li>
-                                <a href="http://wordpress.org/extend/plugins/debug-bar/">Debug Bar</a> Maintained by core devs
+                                <a href="http://wordpress.org/extend/plugins/debug-bar/">Debug Bar</a> - Maintained by core devs
                             </li>
                             <li>
-                                <a href="http://wordpress.org/extend/plugins/debug-bar-extender/">Debug Bar Extender</a> Adds profiler and extra tools
+                                <a href="http://wordpress.org/extend/plugins/debug-bar-extender/">Debug Bar Extender</a> - Adds profiler and extra tools
                             </li>
                             <li>
-                                <a href="http://wordpress.org/extend/plugins/debug-bar-cron/">Debug Bar Cron</a> Display scheduled events
+                                <a href="http://wordpress.org/extend/plugins/debug-bar-cron/">Debug Bar Cron</a> - Display scheduled events
                             </li>
                             <li>
-                                <a href="http://wordpress.org/extend/plugins/debug-bar-transients/">Debug Bar Transients</a> Transient info
+                                <a href="http://wordpress.org/extend/plugins/debug-bar-transients/">Debug Bar Transients</a> - Transient info
                             </li>
                             <li>
-                                <a href="http://wordpress.org/extend/plugins/debug-bar-template-trace/">Debug Bar Template Trace</a> Template load and order
+                                <a href="http://wordpress.org/extend/plugins/debug-bar-template-trace/">Debug Bar Template Trace</a> - Template load and order
                             </li>
                             <li>
-                                <a href="http://wordpress.org/extend/plugins/debug-bar-action-hooks/">Debug Bar Action Hooks</a> List fired hooks
+                                <a href="http://wordpress.org/extend/plugins/debug-bar-action-hooks/">Debug Bar Action Hooks</a> - List fired hooks
                             </li>
                         </ul>
                         <ul>
@@ -275,34 +275,34 @@ $ git push
                                 </h5>
                             </li>
                             <li>
-                                <a href="http://wordpress.org/extend/plugins/core-control/">Core Control</a> Lots of core options
+                                <a href="http://wordpress.org/extend/plugins/core-control/">Core Control</a> - Lots of core options
                             </li>
                             <li>
-                                <a href="http://wordpress.org/extend/plugins/developer/installation/">Developer</a> Quickly get setup
+                                <a href="http://wordpress.org/extend/plugins/developer/installation/">Developer</a> - Quickly get setup
                             </li>
                             <li>
-                                <a href="http://wordpress.org/extend/plugins/debug-this/">Debug This</a> Lot of debuh modes
+                                <a href="http://wordpress.org/extend/plugins/debug-this/">Debug This</a> - Lot of debuh modes
                             </li>
                             <li>
-                                <a href="http://wordpress.org/extend/plugins/p3-profiler/">P3 (Plugin Performance Profiler)</a> Test your plugins
+                                <a href="http://wordpress.org/extend/plugins/p3-profiler/">P3 (Plugin Performance Profiler)</a> - Test your plugins
                             </li>
                             <li>
-                                <a href="http://wordpress.org/extend/plugins/debug-objects/">Debug Objects</a> Lots of info
+                                <a href="http://wordpress.org/extend/plugins/debug-objects/">Debug Objects</a> - Lots of info
                             </li>
                             <li>
-                                <a href="http://wordpress.org/extend/plugins/wordpress-hook-sniffer/">Hook Sniffer</a> Action and filter sequence
+                                <a href="http://wordpress.org/extend/plugins/wordpress-hook-sniffer/">Hook Sniffer</a> - Action and filter sequence
                             </li>
                             <li>
-                                <a href="http://wordpress.org/extend/plugins/log-deprecated-notices/">Depreciated Notices</a> Log outdated functions
+                                <a href="http://wordpress.org/extend/plugins/log-deprecated-notices/">Depreciated Notices</a> - Log outdated functions
                             </li>
                             <li>
-                                <a href="http://wordpress.org/extend/plugins/monkeyman-rewrite-analyzer/">Rewrite Analyzer</a> Helps dreaded rewrites 
+                                <a href="http://wordpress.org/extend/plugins/monkeyman-rewrite-analyzer/">Rewrite Analyzer</a> - Helps dreaded rewrites 
                             </li>
                             <li>
-                                <a href="http://wordpress.org/extend/plugins/wp-xhprof-profiler/">XHProf Profiler</a> Profile plug ins and themes using XHProf (Facebook)
+                                <a href="http://wordpress.org/extend/plugins/wp-xhprof-profiler/">XHProf Profiler</a> - Profile plug ins and themes using XHProf (Facebook)
                             </li>
                             <li>
-                                <a href="http://wordpress.org/extend/plugins/blackbox-debug-bar/">BlackBox Debug Bar</a> Another debug bar
+                                <a href="http://wordpress.org/extend/plugins/blackbox-debug-bar/">BlackBox Debug Bar</a> - Another debug bar
                             </li>
                         </ul>
                         <h5>
@@ -340,16 +340,16 @@ $ git push
                                 </h5>
                             </li>
                             <li>
-                                <a href="https://github.com/tommcfarlin/WordPress-Plugin-Boilerplate">Plugin boilerplate</a> @tommcfarlin
+                                <a href="https://github.com/tommcfarlin/WordPress-Plugin-Boilerplate">Plugin boilerplate</a> by @tommcfarlin
                             </li>
                             <li>
                                 <a href="https://github.com/convissor/oop-plugin-template-solution">Object Oriented Plugin Template</a>
                             </li>
                             <li>
-                                <a href="https://github.com/gilbitron/WordPress-Settings-Framework">Settings framework</a> @gilbitron
+                                <a href="https://github.com/gilbitron/WordPress-Settings-Framework">Settings framework</a> by @gilbitron
                             </li>
                             <li>
-                                <a href="http://wordpress.org/extend/plugins/scb-framework/">scbFramework</a> Classes for plugin dev
+                                <a href="http://wordpress.org/extend/plugins/scb-framework/">scbFramework</a> - Classes for plugin dev
                             </li>
                         </ul>
                         <ul>


### PR DESCRIPTION
Change Wordpress -> WordPress, github/Github -> GitHub and add dashes after links.
