### PR TITLE
Add alternative to WP Stack for deploys: Capistrano-WP

### DIFF
--- a/index.md
+++ b/index.md
@@ -54,6 +54,7 @@ Base Tools
 ##### Build scripts
 
 -   [WP Stack](https://github.com/markjaquith/WP-Stack) - Capistrano deploy
+-   [Capistrano-WP](https://github.com/crowdfavorite/gem-capistrano-wp) - Alternative Capistrano deploy
 -   [Wordmove](https://github.com/welaika/wordmove) - Rails gem
 -   [Wp Project Tools](https://github.com/newsapps/wp-project-tools) - Fabric/Python CLI and automation
 -   [WordPhing](https://github.com/wycks/WordPhing) - Phing/Php build script


### PR DESCRIPTION
Capistrano-WP is another deploy script for WordPress but makes different assumptions than WP Stack. Primarily, WP-Stack expects WordPress Core to be included in the project as a git submodule; these recipes pull WordPress in from SVN.
