### PR TITLE
Add link to WordPress Theme Boilerplate

### DIFF
--- a/index.md
+++ b/index.md
@@ -199,6 +199,7 @@ Theme Stuff
 -   [Grunt-WP-Theme](https://github.com/10up/grunt-wp-theme) - Grunt Scaffold (node)
 -   [Prometheus](https://github.com/noeltock/prometheus) Front-end foundation (LESS, wpthumb)
 -   [WordPress Template Base](https://github.com/wycks/WordPress-Template-Base) File structure based on TwentyEleven
+-   [Theme Boilerplate](https://github.com/bungeshea/theme-boilerplate) Grunt, Sass + Compass, Hybrid Core starter theme
 
 
 


### PR DESCRIPTION
Shameless self promotion. A starter theme I made which uses [Hybrid Core](https://github.com/justintadlock/hybrid-core), [Grunt](http:/gruntjs.com), and [Sass](http://sass-lang.com) + [Compass](http://compass-style.com) https://github.com/bungeshea/theme-boilerplate
