### PR TITLE
Move SublimeWordPressCodex into the IDE section

### DIFF
--- a/index.md
+++ b/index.md
@@ -82,11 +82,11 @@ Base Tools
 -   [Vim WordPress snippets](https://github.com/sudar/vim-wordpress-snippets)
 -   [NetBeans WordPress plugin](https://github.com/junichi11/netbeans-wordpress-plugin/)
 -   [Alfred v2 codex function reference](http://www.alfredforum.com/topic/2153-search-the-wordpress-function-reference/)
+-   [Sublime Codex](https://github.com/welovewordpress/SublimeWordPressCodex) - Search the WordPress Codex inside Sublime
 
 
 `Misc` 
 
--   [Sublime Codex](https://github.com/welovewordpress/SublimeWordPressCodex) - Search the WordPress Codex inside Sublime
 -   [WP-PhpTidy](https://github.com/scribu/wp-phptidy) - Format PHP code so that it conforms to the WordPress Coding Standards
 -   [Nginx](https://github.com/perusio/wordpress-nginx) - Configuration for running WordPress
 -   [WordPress-Skeleton](https://github.com/markjaquith/WordPress-Skeleton) - Basic layout of a WordPress Git repository


### PR DESCRIPTION
Move SublimeWordPressCodex into the IDE section (it's a package for Sublime Text)
