### PR TITLE
Add vagrant autosites

### DIFF
--- a/index.md
+++ b/index.md
@@ -86,6 +86,12 @@ Base Tools
 
 
 
+##### Auto-sites for Varying Vagrant Vagrants
+-   [VVV Site Creation Wizard](https://github.com/bradp/vv) - Easily create new site setups for VVV.
+-   [WP Reference](https://github.com/keesiemeijer/wp-reference) - VVV auto-site setup to obtain a local version of the developer code reference.
+-   [Theme Review](https://github.com/aubreypwd/wordpress-themereview-vvv) - VVV auto-site setup for reviewing and testing themes for WordPress.org themes.
+-   [Plugin Development & Debugging](https://github.com/jrfnl/wordpress-plugins-tutorial) - VVV auto-site setup for developing, testing and debugging plugins.
+
 
 `IDE bundles`
 

--- a/index.md
+++ b/index.md
@@ -86,11 +86,14 @@ Base Tools
 
 
 
-##### Auto-sites for Varying Vagrant Vagrants
+##### Add-ons for Varying Vagrant Vagrants
 -   [VVV Site Creation Wizard](https://github.com/bradp/vv) - Easily create new site setups for VVV.
 -   [WP Reference](https://github.com/keesiemeijer/wp-reference) - VVV auto-site setup to obtain a local version of the developer code reference.
 -   [Theme Review](https://github.com/aubreypwd/wordpress-themereview-vvv) - VVV auto-site setup for reviewing and testing themes for WordPress.org themes.
 -   [Plugin Development & Debugging](https://github.com/jrfnl/wordpress-plugins-tutorial) - VVV auto-site setup for developing, testing and debugging plugins.
+-   [VVV Dashboard](https://github.com/topdown/VVV-Dashboard) - advanced dashboard with ability to turn WP_DEBUG on/off per site, create database backups, purge cache and more.
+-   [VVV Dashboard](https://github.com/leogopal/VVV-Dashboard) - simple dashboard with links to all sites, their admin and profiler.
+-   [VVV Dashboard](https://github.com/stevenkword/vvv-dashboard-custom) - simple dashboard with wapuu icons.
 
 
 `IDE bundles`

--- a/index.md
+++ b/index.md
@@ -88,9 +88,9 @@ Base Tools
 
 ##### Add-ons for Varying Vagrant Vagrants
 -   [VVV Site Creation Wizard](https://github.com/bradp/vv) - Easily create new site setups for VVV.
--   [WP Reference](https://github.com/keesiemeijer/wp-reference) - VVV auto-site setup to obtain a local version of the developer code reference.
--   [Theme Review](https://github.com/aubreypwd/wordpress-themereview-vvv) - VVV auto-site setup for reviewing and testing themes for WordPress.org themes.
--   [Plugin Development & Debugging](https://github.com/jrfnl/wordpress-plugins-tutorial) - VVV auto-site setup for developing, testing and debugging plugins.
+-   [WP Reference](https://github.com/keesiemeijer/wp-reference) - VVV [auto-site setup](https://github.com/Varying-Vagrant-Vagrants/VVV/wiki/Auto-site-Setup) to obtain a local version of the developer code reference.
+-   [Theme Review](https://github.com/aubreypwd/wordpress-themereview-vvv) - VVV [auto-site setup](https://github.com/Varying-Vagrant-Vagrants/VVV/wiki/Auto-site-Setup) for reviewing and testing themes for WordPress.org themes.
+-   [Plugin Development & Debugging](https://github.com/jrfnl/wordpress-plugins-tutorial) - VVV [auto-site setup](https://github.com/Varying-Vagrant-Vagrants/VVV/wiki/Auto-site-Setup) for developing, testing and debugging plugins.
 -   [VVV Dashboard](https://github.com/topdown/VVV-Dashboard) - advanced dashboard with ability to turn WP_DEBUG on/off per site, create database backups, purge cache and more.
 -   [VVV Dashboard](https://github.com/leogopal/VVV-Dashboard) - simple dashboard with links to all sites, their admin and profiler.
 -   [VVV Dashboard](https://github.com/stevenkword/vvv-dashboard-custom) - simple dashboard with wapuu icons.


### PR DESCRIPTION
Varying Vagrant Vagrants when up will provide a few autosites for you, such as a dev environment for core and a normal test environment for core.

However there are a number of other autosite scripts available by now which provide useful extra autosites which can be added to the VVV box, such as the developer reference, a theme review autosite, a plugin development autosite and more.

Also the VVV dashboard is a bit bare with a standard VVV. There are a number of other Dahsboards out there now which work with VVV to provide a better experience.

Added these kind of add-ons in their own section.
