### PR TITLE
Update information about PHPCompatibility

### DIFF
--- a/index.md
+++ b/index.md
@@ -115,7 +115,7 @@ Base Tools
 -   [WordPress Coding Standards Handbook](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) - The official CSS, HTML, JS and PHP coding standards for WordPress.
 -   [WordPress-Coding-Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) - PHP CodeSniffer - enforce WordPress coding conventions.
 -   [WP-PhpTidy](https://github.com/scribu/wp-phptidy) - Format PHP code so that it conforms to the WordPress Coding Standards.
--   [PHPCompatibility](https://github.com/wimg/PHPCompatibility) - PHP CodeSniffer to test your code for PHP cross-version compatibility so you can catch those non-PHP 5.2 compatible syntaxes early.
+-   [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) - A WP-ified version of the [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) PHP CodeSniffer ruleset to test your code for PHP cross-version compatibility so you can catch those non-PHP 5.2 compatible syntaxes early.
 -   [JSHint Config](https://develop.svn.wordpress.org/trunk/.jshintrc) - The official JS hint configuration.
 
 


### PR DESCRIPTION
The repository for the PHPCompatibility project has moved to its own GitHub organisation.

Within that organisation, CMS-specific repos have been created which contain custom rulesets based on PHPCompatibility which take back-fills/poly-fills included in the CMS into account.

It is recommended for projects which expect to be run within a WordPress context - i.e. WordPress itself, plugins and themes -, to use the WP specific PHPCompatibility ruleset to reduce false positives.

For more information:
* https://github.com/PHPCompatibility/PHPCompatibilityWP
* https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/8.2.0

