### PR TITLE
Fix outdated links to the repository

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -55,7 +55,7 @@
 
            </section>
         <footer>
-            <a href="https://github.com/wycks/WordPress-Gear" class="button fork"><strong>GitHub Fork</strong></a>
+            <a href="https://github.com/wecodemore/WordPress-Gear" class="button fork"><strong>GitHub Fork</strong></a>
             <p><small>Hosted on GitHub Pages — Theme <a href="https://github.com/mojombo/jekyll">Jekyllized</a> by <a href="https://twitter.com/wycks_s">wycks</a> forked from <a href="https://twitter.com/michigangraham">mattgraham</a></small></p>
         </footer>
         <!--[if !IE]><script>fixScale(document);</script><![endif]-->

--- a/index.md
+++ b/index.md
@@ -4,9 +4,9 @@ layout: default
 
 ### How
 
-WordPress-Gear is meant to be community driven, please feel free to jump in and add/remove any useful information via [GitHub](https://github.com/wycks/WordPress-Gear).
+WordPress-Gear is meant to be community driven, please feel free to jump in and add/remove any useful information via [GitHub](https://github.com/wecodemore/WordPress-Gear).
 
-The easiest way to contribute is to have a GitHub account then click [index.md](https://github.com/wycks/WordPress-Gear/blob/gh-pages/index.md), then click edit. This will automatically fork this project to your account so you can make changes, then submit a pull request. There are additional instruction if you want to clone this locally in the readme.
+The easiest way to contribute is to have a GitHub account then click [index.md](https://github.com/wecodemore/WordPress-Gear/blob/gh-pages/index.md), then click edit. This will automatically fork this project to your account so you can make changes, then submit a pull request. There are additional instruction if you want to clone this locally in the readme.
 
 
 ### Contributors


### PR DESCRIPTION
Fixes three links to this repos which still referenced `wycks` instead of `wecodemore`.